### PR TITLE
Sends signing request after hearing the AUTH_LOADED event

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "@fractalwagmi/solana-wallet-adapter",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@fractalwagmi/solana-wallet-adapter",
-      "version": "0.0.3",
+      "version": "0.0.4",
       "license": "ISC",
       "dependencies": {
-        "@fractalwagmi/popup-connection": "^1.0.11",
+        "@fractalwagmi/popup-connection": "^1.0.12",
         "@solana/wallet-adapter-base": "^0.9.17",
         "bs58": "^5.0.0"
       },
@@ -714,9 +714,9 @@
       }
     },
     "node_modules/@fractalwagmi/popup-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.0.11.tgz",
-      "integrity": "sha512-miEg+oNKZ/IA7bnBTbYOrH3zTMWiBbzwTl7Ko6hKPRwRnvgtqfpgRvmnl6nwtaZJqkiKUJLkztHYdTrR1P3afQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.0.12.tgz",
+      "integrity": "sha512-kEiXBA1E8jPaB83Yjofz/bz3LUHRiPFsf96wZeuVsdC4BIkMMrlcfKGUfo/m3Bst6/gGLYCJBRZnaRCH0HYICg==",
       "peerDependencies": {
         "react": "^16 || ^17 || ^18",
         "react-dom": "^16 || ^17 || ^18"
@@ -9604,9 +9604,9 @@
       }
     },
     "@fractalwagmi/popup-connection": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.0.11.tgz",
-      "integrity": "sha512-miEg+oNKZ/IA7bnBTbYOrH3zTMWiBbzwTl7Ko6hKPRwRnvgtqfpgRvmnl6nwtaZJqkiKUJLkztHYdTrR1P3afQ==",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/@fractalwagmi/popup-connection/-/popup-connection-1.0.12.tgz",
+      "integrity": "sha512-kEiXBA1E8jPaB83Yjofz/bz3LUHRiPFsf96wZeuVsdC4BIkMMrlcfKGUfo/m3Bst6/gGLYCJBRZnaRCH0HYICg==",
       "requires": {}
     },
     "@humanwhocodes/config-array": {

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "typescript-transform-paths": "^3.3.1"
   },
   "dependencies": {
-    "@fractalwagmi/popup-connection": "^1.0.11",
+    "@fractalwagmi/popup-connection": "^1.0.12",
     "@solana/wallet-adapter-base": "^0.9.17",
     "bs58": "^5.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/solana-wallet-adapter",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Solana wallet adapter implementation for Fractal Wallet",
   "main": "dist/cjs/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/core/fractal-wallet-adapter-impl.test.ts
+++ b/src/core/fractal-wallet-adapter-impl.test.ts
@@ -248,6 +248,7 @@ describe('FractalWalletAdapterImpl', () => {
     let onTransactionSignatureNeededResponseCallback: (
       payload: unknown,
     ) => void = () => {};
+    let onAuthLoadedCallback: EventCallback = () => {};
 
     beforeEach(async () => {
       wallet = new FractalWalletAdapterImpl();
@@ -288,7 +289,20 @@ describe('FractalWalletAdapterImpl', () => {
       });
 
       wallet.signTransaction(TEST_TRANSACTION);
+      mockConnection.on.mockImplementation((event, callback) => {
+        if (event === PopupEvent.AUTH_LOADED) {
+          onAuthLoadedCallback = callback;
+        }
+      });
       onConnectionUpdatedCallback(mockConnection);
+
+      expect(mockConnection.send).not.toHaveBeenCalledWith({
+        event: PopupEvent.TRANSACTION_SIGNATURE_NEEDED,
+        payload: expect.objectContaining({
+          unsignedB58Transactions: [expect.any(String)],
+        }),
+      });
+      onAuthLoadedCallback();
 
       expect(mockConnection.send).toHaveBeenLastCalledWith({
         event: PopupEvent.TRANSACTION_SIGNATURE_NEEDED,

--- a/src/core/fractal-wallet-adapter-impl.ts
+++ b/src/core/fractal-wallet-adapter-impl.ts
@@ -195,6 +195,18 @@ export class FractalWalletAdapterImpl {
       this.popupManager.close();
     };
 
+    const handleAuthLoaded = () => {
+      const payload: TransactionSignatureNeededPayload = {
+        unsignedB58Transactions: transactions.map(t =>
+          base58.encode(t.serializeMessage()),
+        ),
+      };
+      this.popupManager.getConnection()?.send({
+        event: PopupEvent.TRANSACTION_SIGNATURE_NEEDED,
+        payload,
+      });
+    };
+
     const nonce = createNonce();
     this.popupManager.open({
       heightPx: Math.max(
@@ -217,18 +229,8 @@ export class FractalWalletAdapterImpl {
         PopupEvent.TRANSACTION_SIGNATURE_NEEDED_RESPONSE,
         handleTransactionSignatureNeededResponse,
       );
-
       connection.on(PopupEvent.POPUP_CLOSED, handleClosedByUser);
-
-      const payload: TransactionSignatureNeededPayload = {
-        unsignedB58Transactions: transactions.map(t =>
-          base58.encode(t.serializeMessage()),
-        ),
-      };
-      connection.send({
-        event: PopupEvent.TRANSACTION_SIGNATURE_NEEDED,
-        payload,
-      });
+      connection.on(PopupEvent.AUTH_LOADED, handleAuthLoaded);
     });
 
     return new Promise<T[]>((promiseResolver, promiseRejector) => {


### PR DESCRIPTION
There was a race condition in the wallet adapter code where the popup page was making an `explainTransaction` API call without having completed the fetching of wallet information. This ensures that doesn't happen.