### PR TITLE
Fixes sign message bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fractalwagmi/solana-wallet-adapter",
-  "version": "0.0.10",
+  "version": "0.0.11",
   "description": "Solana wallet adapter implementation for Fractal Wallet",
   "main": "dist/cjs/index.js",
   "types": "dist/esm/index.d.ts",

--- a/src/core/fractal-wallet-adapter-impl.test.ts
+++ b/src/core/fractal-wallet-adapter-impl.test.ts
@@ -399,13 +399,11 @@ describe('FractalWalletAdapterImpl', () => {
       onConnectionUpdatedCallback(mockConnection);
 
       onMessageSignatureNeededResponseCallback({
-        decodedSignature: 'SOME_DECODED_SIGNATURE',
+        decodedSignature: '97,98,99',
       });
       const result = await signMessageP;
 
-      expect(result).toEqual(
-        new TextEncoder().encode('SOME_DECODED_SIGNATURE'),
-      );
+      expect(result).toEqual(Uint8Array.from([97, 98, 99]));
       expect(mockConnectionManager.close).toHaveBeenCalled();
     });
   });

--- a/src/core/fractal-wallet-adapter-impl.ts
+++ b/src/core/fractal-wallet-adapter-impl.ts
@@ -180,8 +180,8 @@ export class FractalWalletAdapterImpl {
         return;
       }
 
-      const encodedSignature = new TextEncoder().encode(
-        payload.decodedSignature,
+      const encodedSignature = Uint8Array.from(
+        payload.decodedSignature.split(',').map(n => Number(n)),
       );
       resolve(encodedSignature);
     };


### PR DESCRIPTION
This is fixing a bug in the sign message flow as the current implementation assumes that the signature that comes back is a utf-8 encoded text, which it is not. Running the signature through TextEncoder was screwing up the signature value.